### PR TITLE
[InhaLostFoundAPI] 키오스크 API 추가

### DIFF
--- a/LostFoundAPI/app/controller/kiosks.py
+++ b/LostFoundAPI/app/controller/kiosks.py
@@ -1,0 +1,57 @@
+# LostFoundAPI/app/controller/kiosks.py
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+
+from app.db.session import get_db
+from app.service import kiosk_service
+from app.schemas import item as item_schema
+
+router = APIRouter()
+
+# 픽업 코드 검증 및 상태 변경 요청 모델
+class PickupRequest(BaseModel):
+    pickup_code: str # 키오스크에 입력된 6자리 코드
+
+# 응답 모델 (픽업 코드가 유효했을 때 반환)
+class KioskPickupResponse(BaseModel):
+    message: str
+    item: item_schema.ItemResponse # 상태가 '찾음'으로 변경된 아이템 정보
+
+# 픽업 코드 검증 및 아이템 상태 변경 API
+@router.post("/pickup", response_model=KioskPickupResponse)
+async def complete_item_pickup(
+        pickup_data: PickupRequest,
+        db: Session = Depends(get_db)
+):
+    """
+    (키오스크 전용) 픽업 코드를 검증하고, 유효하면 해당 분실물의 상태를
+    '보관'에서 '찾음'으로 변경합니다.
+    """
+
+    # 서비스 로직 호출
+    result = kiosk_service.complete_pickup_by_code(
+        db=db,
+        pickup_code_str=pickup_data.pickup_code
+    )
+
+    if result == "INVALID_CODE":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="유효하지 않거나 만료된 픽업 코드입니다."
+        )
+    if result == "ALREADY_PICKED_UP":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="이미 '찾음' 처리된 분실물입니다."
+        )
+    if result == "NOT_IN_STORAGE":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="보관 상태가 아닌 분실물입니다. (분실 상태이거나, 다른 상태)"
+        )
+
+    return {
+        "message": f"픽업 코드 {pickup_data.pickup_code}가 확인되었으며, 아이템이 인계되었습니다.",
+        "item": result
+    }

--- a/LostFoundAPI/app/main.py
+++ b/LostFoundAPI/app/main.py
@@ -4,6 +4,7 @@ from mangum import Mangum
 from app.controller import items as items_router
 from app.controller import users as users_router
 from app.controller import tags as tags_router
+from app.controller import kiosks as kiosks_router
 
 app = FastAPI(
     title="Inha LostFound API",
@@ -22,5 +23,6 @@ def read_root():
 app.include_router(items_router.router, prefix="/items", tags=["Items"])
 app.include_router(users_router.router, prefix="/users", tags=["Users"])
 app.include_router(tags_router.router, prefix="/tags", tags=["Tags"])
+app.include_router(kiosks_router.router, prefix="/kiosk", tags=["Kiosk"])
 
 handler = Mangum(app)

--- a/LostFoundAPI/app/service/kiosk_service.py
+++ b/LostFoundAPI/app/service/kiosk_service.py
@@ -1,0 +1,47 @@
+# LostFoundAPI/app/service/kiosk_service.py
+from sqlalchemy.orm import Session
+import datetime
+
+from app.models import PickupCodes
+from app.service.item_service import get_item_by_id_with_tags
+
+
+def complete_pickup_by_code(db: Session, pickup_code_str: str):
+    """
+    픽업 코드를 검증하고, 유효하면 아이템 상태를 '찾음'으로 변경합니다.
+    """
+
+    # 유효하고 만료되지 않은 픽업 코드를 찾습니다.
+    now = datetime.datetime.utcnow()
+
+    pickup_code_record = db.query(PickupCodes).filter(
+        PickupCodes.code == pickup_code_str,
+        PickupCodes.expires_at > now,
+        PickupCodes.is_used == False
+    ).first()
+
+    if not pickup_code_record:
+        return "INVALID_CODE" # 404/400 (코드 없음, 만료, 이미 사용됨)
+
+    # 아이템을 가져옵니다. (item_service 재사용)
+    item = get_item_by_id_with_tags(db, item_id=pickup_code_record.lost_item_id)
+
+    if not item:
+        return "INVALID_CODE"
+
+    if item.status == "찾음":
+        return "ALREADY_PICKED_UP"
+
+    if item.status != "보관":
+        return "NOT_IN_STORAGE"
+
+    # 상태 변경 및 기록 업데이트
+    item.status = "찾음"
+    item.found_at = now
+
+    pickup_code_record.is_used = True
+
+    db.commit()
+    db.refresh(item)
+
+    return item


### PR DESCRIPTION
키오스크 장치에서 픽업 코드를 검증하고 아이템 상태를 변경하기 위한 전용 API 엔드포인트를 추가합니다.

- `app/controller/kiosks.py`: POST /kiosk/pickup 엔드포인트를 정의합니다.
- `app/main.py`: 새로운 /kiosk 라우터를 애플리케이션에 등록합니다.
- 토큰 인증이 필요 없는 공용 API로 설계하여 키오스크 사용성을 확보합니다.